### PR TITLE
Add Maven Central publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # KDownloader
 
+[![Maven Central](https://img.shields.io/maven-central/v/dev.onexeor/kdownloader)](https://central.sonatype.com/artifact/dev.onexeor/kdownloader)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.3.0-purple.svg)](https://kotlinlang.org)
 [![Platform](https://img.shields.io/badge/Platform-Android%20%7C%20iOS-green.svg)](https://kotlinlang.org/docs/multiplatform.html)
@@ -20,23 +21,10 @@ A lightweight Kotlin Multiplatform download manager for Android and iOS. Uses pl
 
 ## Installation
 
-Add the GitHub Packages repository and dependency to your project:
+Add the dependency to your KMP module:
 
 ```kotlin
-// settings.gradle.kts
-dependencyResolutionManagement {
-    repositories {
-        maven {
-            url = uri("https://maven.pkg.github.com/OneXeor/KDownloader")
-            credentials {
-                username = providers.gradleProperty("gpr.user").orNull ?: System.getenv("USERNAME")
-                password = providers.gradleProperty("gpr.token").orNull ?: System.getenv("API_KEY")
-            }
-        }
-    }
-}
-
-// build.gradle.kts (shared module)
+// build.gradle.kts
 kotlin {
     sourceSets {
         commonMain.dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform).apply(false)
     alias(libs.plugins.kotlinAndroid).apply(false)
     alias(libs.plugins.composeCompiler).apply(false)
+    alias(libs.plugins.mavenPublish).apply(false)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,3 +9,20 @@ kotlin.code.style=official
 #Android
 android.useAndroidX=true
 android.nonTransitiveRClass=true
+
+# Library Version
+VERSION_NAME=1.0.0
+
+# Maven Central Publishing
+GROUP=dev.onexeor
+POM_ARTIFACT_ID=kdownloader
+POM_NAME=KDownloader
+POM_DESCRIPTION=Kotlin Multiplatform download manager for Android and iOS
+POM_URL=https://github.com/OneXeor/KDownloader
+POM_SCM_URL=https://github.com/OneXeor/KDownloader
+POM_SCM_CONNECTION=scm:git:git://github.com/OneXeor/KDownloader.git
+POM_SCM_DEV_CONNECTION=scm:git:ssh://github.com/OneXeor/KDownloader.git
+POM_LICENCE_NAME=Apache License, Version 2.0
+POM_LICENCE_URL=https://www.apache.org/licenses/LICENSE-2.0.txt
+POM_DEVELOPER_ID=onexeor
+POM_DEVELOPER_NAME=Viktor Savchik

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 agp = "8.7.3"
 kotlin = "2.3.0"
+mavenPublish = "0.30.0"
 coreKtx = "1.15.0"
 composeBom = "2024.12.01"
 androidx-activityCompose = "1.9.3"
@@ -23,3 +24,4 @@ kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinCocoapods = { id = "org.jetbrains.kotlin.native.cocoapods", version.ref = "kotlin" }
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -1,15 +1,14 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidLibrary)
-    id("maven-publish")
+    alias(libs.plugins.mavenPublish)
 }
-
-group = "dev.onexeor"
-version = "1.0.0"
 
 kotlin {
     androidTarget {
-        publishLibraryVariants("release", "debug")
+        publishLibraryVariants("release")
         compilations.all {
             compileTaskProvider.configure {
                 compilerOptions {
@@ -58,23 +57,7 @@ dependencies {
     implementation(libs.androidx.core.ktx)
 }
 
-afterEvaluate {
-    publishing {
-        publications.withType<MavenPublication> {
-            artifactId = artifactId.replace("library", "kdownloader")
-        }
-    }
-}
-
-publishing {
-    repositories {
-        maven {
-            name = "KDownloader"
-            url = uri("https://maven.pkg.github.com/OneXeor/KDownloader")
-            credentials {
-                username = System.getenv("USERNAME")
-                password = System.getenv("API_KEY")
-            }
-        }
-    }
+mavenPublishing {
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    signAllPublications()
 }


### PR DESCRIPTION
## Summary
- Replace GitHub Packages with Maven Central (Sonatype Central Portal)
- Add `com.vanniktech.maven.publish` plugin
- Simplify README installation (no auth required for consumers)
- Add Maven Central badge

## Changes
- Removed GitHub Packages repository and credentials
- Added POM metadata to `gradle.properties`
- Simplified dependency declaration in README

## Before
```kotlin
// Required GitHub Packages auth
maven {
    url = uri("https://maven.pkg.github.com/OneXeor/KDownloader")
    credentials { ... }
}
implementation("dev.onexeor:kdownloader:1.0.0")
```

## After
```kotlin
// Just works with mavenCentral()
implementation("dev.onexeor:kdownloader:1.0.0")
```

## Test plan
- [x] Build passes
- [x] Publishing configuration is correct